### PR TITLE
Work around API outage by reading from cache

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -88,7 +88,6 @@ export default class MarvelApi {
 
 		const result = await this.callMarvelApi(COMICS_ENDPOINT, getComicsSearchParams(year, 0, 1));
 		const parsedResult: ComicDataWrapper = await result.json();
-		console.log({ parsedResult });
 
 		if (parsedResult.code === 200) {
 			const { total } = parsedResult.data;
@@ -97,7 +96,7 @@ export default class MarvelApi {
 		}
 
 		try {
-			console.log('Marvel API failed, falling back to cached data');
+			console.log(`Marvel API failed with ${parsedResult.code}, falling back to cached data`);
 			// the total comics count expires, so this is a workaround by counting how many pages of cached data we have for that year
 			const numPages = await this.redis.getCountOfKeysForYear(year);
 			return numPages * 100;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -79,11 +79,11 @@ export default class MarvelApi {
 		return parsedResult;
 	}
 
-	async getTotalComics(year: number): Promise<number> {
+	async getTotalComics(year: number): Promise<{ total: number; fallbackUsed?: boolean }> {
 		const key = `year:${year}:total`;
 		const val = await this.redis.get<number>(key, parseInt);
 		if (val && !this.ignoreCache) {
-			return val;
+			return { total: val };
 		}
 
 		const result = await this.callMarvelApi(COMICS_ENDPOINT, getComicsSearchParams(year, 0, 1));
@@ -92,19 +92,19 @@ export default class MarvelApi {
 		if (parsedResult.code === 200) {
 			const { total } = parsedResult.data;
 			await this.redis.set(key, total);
-			return total;
+			return { total };
 		}
 
 		try {
 			console.log(`Marvel API failed with ${parsedResult.code}, falling back to cached data`);
 			// the total comics count expires, so this is a workaround by counting how many pages of cached data we have for that year
 			const numPages = await this.redis.getCountOfKeysForYear(year);
-			return numPages * 100;
+			return { total: numPages * 100, fallbackUsed: true };
 		} catch (e) {
 			console.log('unable to fallback to redis keys', e);
 		}
 
-		return -1;
+		return { total: -1 };
 	}
 
 	async getRandomComics(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -67,13 +67,15 @@ export default class MarvelApi {
 		);
 
 		console.log('called Marvel API in', (performance.now() - start) / 1000);
-		start = performance.now();
 
 		const parsedResult: ComicDataWrapper = await result.json();
 		if (parsedResult.code === 200) {
+			start = performance.now();
 			await this.redis.addComics(year, page, parsedResult, comicIdsWithImages);
+			console.log('updated redis in', (performance.now() - start) / 1000);
+		} else {
+			console.log(`API returned ${parsedResult.code}`);
 		}
-		console.log('updated redis in', (performance.now() - start) / 1000);
 		return parsedResult;
 	}
 
@@ -86,12 +88,23 @@ export default class MarvelApi {
 
 		const result = await this.callMarvelApi(COMICS_ENDPOINT, getComicsSearchParams(year, 0, 1));
 		const parsedResult: ComicDataWrapper = await result.json();
+		console.log({ parsedResult });
 
 		if (parsedResult.code === 200) {
 			const { total } = parsedResult.data;
 			await this.redis.set(key, total);
 			return total;
 		}
+
+		try {
+			console.log('Marvel API failed, falling back to cached data');
+			// the total comics count expires, so this is a workaround by counting how many pages of cached data we have for that year
+			const numPages = await this.redis.getCountOfKeysForYear(year);
+			return numPages * 100;
+		} catch (e) {
+			console.log('unable to fallback to redis keys', e);
+		}
+
 		return -1;
 	}
 

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -237,6 +237,20 @@ export default class RedisClient {
 		return await this.getRandomComicsFromIds(ids);
 	}
 
+	async getCountOfKeysForYear(year: number) {
+		const pattern = `year:${year}:*:c`;
+		let cursor = '0';
+		let count = 0;
+
+		do {
+			const [newCursor, keys] = await this.redis.scan(cursor, 'MATCH', pattern);
+			cursor = newCursor;
+			count += keys.length;
+		} while (cursor !== '0');
+
+		return count;
+	}
+
 	async quit() {
 		if (this.closed) return;
 		await this.redis.quit();

--- a/src/routes/year/[year=year]/+page.server.ts
+++ b/src/routes/year/[year=year]/+page.server.ts
@@ -38,7 +38,7 @@ async function getComics({ params, setHeaders, url }: RequestEvent) {
 	const api = new MarvelApi(redis, url.origin, ignoreCache);
 
 	console.log(`Getting comics for ${year}`);
-	let totalComics = await api.getTotalComics(year);
+	let { total: totalComics, fallbackUsed } = await api.getTotalComics(year);
 	console.log(`Total comics: ${totalComics}`);
 	if (totalComics === -1) {
 		console.log(`unable to fetch total comics for ${year}`);
@@ -73,7 +73,8 @@ async function getComics({ params, setHeaders, url }: RequestEvent) {
 
 		return {
 			response,
-			year
+			year,
+			fallbackUsed
 		};
 	}
 

--- a/src/routes/year/[year=year]/+page.svelte
+++ b/src/routes/year/[year=year]/+page.svelte
@@ -129,6 +129,11 @@
 </script>
 
 <h1>{$page.data.title || `Comics for ${data.year}`}</h1>
+{#if data.fallbackUsed}
+	<div class="fallback-banner">
+		The Marvel API is down, so this page is using cached data. The data may be outdated.
+	</div>
+{/if}
 <PageLinks year={data.year} />
 
 <p>
@@ -210,6 +215,13 @@
 {/if}
 
 <style>
+	.fallback-banner {
+		background-color: var(--red-3);
+		padding: var(--size-2);
+		width: 100%;
+		border-radius: var(--radius-2);
+		font-size: var(--font-size-1);
+	}
 	.filters {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(15.625rem, 1fr));


### PR DESCRIPTION
The Marvel API is down. Luckily most of the data is cached (but stale), except for the total number of comics for a given year. This makes it so when we can't retrieve the total comics for a given year, we derive it by seeing how many pages of cached data we have.

This isn't perfect, but should allow the site to serve stale content during an outage.